### PR TITLE
Fix to proceed with calibration when email can't be sent

### DIFF
--- a/OOCalibrationToolbox/@Calibrator/promptUserThatCalibrationIsDone.m
+++ b/OOCalibrationToolbox/@Calibrator/promptUserThatCalibrationIsDone.m
@@ -18,7 +18,11 @@ function promptUserThatCalibrationIsDone(obj,beepWhenDone)
         Snd('Play',sin(0:10000));
         pause(0.3);
         Snd('Play',sin(0:10000));
-        sendmail(obj.cal.describe.doneNotificationEmail, 'Calibration Complete', 'All done!');
+        try
+            sendmail(obj.cal.describe.doneNotificationEmail, 'Calibration Complete', 'All done!');
+        catch e
+            fprintf('\nCouldn''t send completion email, proceeding anyway.\n');
+        end
     end
     
 end


### PR DESCRIPTION
`sendmail` will throw an error in case an email can't be sent. This fix now wraps the `sendmail` command in a `try...catch` statement.