### PR TITLE
Radiometer destructor

### DIFF
--- a/OOCalibrationToolbox/@Radiometer/Radiometer.m
+++ b/OOCalibrationToolbox/@Radiometer/Radiometer.m
@@ -126,6 +126,11 @@ classdef Radiometer < handle
             end
         end
         
+        % Destructor
+        function delete(obj)
+            obj.shutDown;
+        end
+        
         % Setter method for property verbosity
         function set.verbosity(obj, new_verbosity)
             obj.privateSetVerbosity(new_verbosity);


### PR DESCRIPTION
Destructor is necessary to ensure proper closing of connections to hardware.

When a Radiometer object is created inside some function, but the function exits without passing this object to somewhere else (e.g., the function exits through an error), the object goes out of scope. Out of scope objects are automatically deleted by MATLAB, consistently, even in the case of error or user abort (CTRL+C).
Objects are also deleted when the last remaining reference to them is overwritten (i.e., `r = Radiometer; r = 1`). When the object is deleted, it means that the object cannot be accessed anymore for any functioning, including shutting down.
There is currently no guarantee that the connections to the hardware are properly closed, and that the device can be accessed again by creating a new Radiometer object.
The class destructor method `delete` will be called automatically by MATLAB anytime an object of the class is deleted. This is allows us to call the `Radiometer.shutDown` method on the object being deleted, thus enforcing some safe disconnecting.