### PR TITLE
Destructor GLWindow

### DIFF
--- a/Classes/@GLWindow/GLWindow.m
+++ b/Classes/@GLWindow/GLWindow.m
@@ -337,8 +337,13 @@ classdef GLWindow < handle
 				otherwise
 					error('Invalid display type of "%s" requested.', GLWObj.DisplayType);
 			end
-		end
+        end
 		
+        % Destructor
+        function delete(GLWObj)
+            close(GLWObj)
+        end
+        
 		% Closes all windows attached to the GLWindow.
 		close(GLWObj)
 		


### PR DESCRIPTION
When a GLWindow object is created inside some function, but the function exits without passing this object to somewhere else (e.g., the function exits through an error), the object goes out of scope. Out of scope objects are automatically deleted by MATLAB, consistently, even in the case of error or user abort (CTRL+C).
Objects are also deleted when the last remaining reference to them is overwritten (i.e., `G = GLWindow; G = 1`). When the object is deleted, it means that the object cannot be accessed anymore for any functioning, including closing the window. This can result in the window display staying up, until `mglClose` is manually called — in some cases, even that won’t do the trick.

There is currently no guarantee that window is properly closed, and that it can be accessed again by creating a new GLWindow object.
The class destructor method `delete` will be called automatically by MATLAB anytime an object of the class is deleted. This is allows us to call the `GLWindow.close()` method on the object being deleted, thus enforcing some safe closing of the window.