### PR TITLE
Bugfix radiometer: would not accurately find portstrings

### DIFF
--- a/OOCalibrationToolbox/@Radiometer/privateGetPortString.m
+++ b/OOCalibrationToolbox/@Radiometer/privateGetPortString.m
@@ -3,18 +3,9 @@
 function obj = privateGetPortString(obj)
     % For each serial type in the portDeviceNames cell array, see if any attached serial
     % devices names match.
-    indices = [];
-    
-    for i = 1:length(obj.portDeviceNames)
-        stringPattern = obj.portDeviceNames{i};
-        for j = 1:length(obj.portDeviceFiles)
-            fprintf('Looking for pattern ''%s'' in string ''%s'' .\n', stringPattern, lower(obj.portDeviceFiles(j).name));
-            if (~isempty(strfind(lower(obj.portDeviceFiles(j).name), stringPattern)))
-                indices = [indices j];
-            end
-        end
-    end
+    indices = find(contains({obj.portDeviceFiles.name},obj.portDeviceNames));
 
+    % Throw error if no matching device file was found
     if (isempty(indices))
         obj.portDeviceNames
         for j = 1:length(obj.portDeviceFiles)
@@ -23,9 +14,9 @@ function obj = privateGetPortString(obj)
         error('No devices found. Make sure that your radiometer is plugged in.');
     end
 
-    numPortsFound = length(indices);
+    % Print which ports we have found
     fprintf('Ports found:\n');
-    for k = 1:numPortsFound
+    for k = 1:length(indices)
         fprintf('[%d]: %s\n', k, obj.portDeviceFiles(indices(k)).name);
     end
 


### PR DESCRIPTION
Not sure why, but occasionally `Radiometer.privateGetPortString` would not correctly find ports of radiometer. In this case, it would report that no radiometer was connected, when in fact it was.
This change seems to fix this.