### PR TITLE
Bugfix Radiometer-class: Remove devicefiles properties

### DIFF
--- a/OOCalibrationToolbox/@Radiometer/Radiometer.m
+++ b/OOCalibrationToolbox/@Radiometer/Radiometer.m
@@ -72,15 +72,6 @@ classdef Radiometer < handle
     properties (Access = private)
         % List of serial port devices to look for.
         portDeviceNames = { lower('keyserial1'), lower('usbmodem'), lower('usbserial'), lower('cu.USA') };
-    
-        % Enumerate cu* devices - they correspond to serial ports:
-        portDeviceFilesCU = dir('/dev/cu*');
-
-        % Enumerate tty.usb* devices - they correspond to serial ports:
-        portDeviceFilesTTY_USB = dir('/dev/tty.usb*');
-
-        % Concatenation of above portDeviceFiles
-        portDeviceFiles;
         
         % Private Verbosity
         privateVerbosity;
@@ -111,9 +102,6 @@ classdef Radiometer < handle
     methods
         % Constructor
         function obj = Radiometer(verbosity, devPortString)
-            % Concatenate all portDevicefiles
-            obj.portDeviceFiles = [obj.portDeviceFilesCU(:); obj.portDeviceFilesTTY_USB(:)];
-        
             obj.verbosity = verbosity;
             if ~isempty(devPortString)
                 obj.portString = devPortString;

--- a/OOCalibrationToolbox/@Radiometer/privateGetPortString.m
+++ b/OOCalibrationToolbox/@Radiometer/privateGetPortString.m
@@ -1,9 +1,19 @@
 % Method to search all known portDeviceNames to determine whether there is a match for the attached serial devices
 %
 function obj = privateGetPortString(obj)
+    % Enumerate cu* devices - they correspond to serial ports:
+    portDeviceFilesCU = dir('/dev/cu*');
+
+    % Enumerate tty.usb* devices - they correspond to serial ports:
+    portDeviceFilesTTY_USB = dir('/dev/tty.usb*');    
+    
+    % Combine port device files
+    portDeviceFiles = [portDeviceFilesCU(:); portDeviceFilesTTY_USB(:)];
+
+
     % For each serial type in the portDeviceNames cell array, see if any attached serial
     % devices names match.
-    indices = find(contains({obj.portDeviceFiles.name},obj.portDeviceNames));
+    indices = find(contains({portDeviceFiles.name},obj.portDeviceNames));
 
     % Throw error if no matching device file was found
     if (isempty(indices))
@@ -17,9 +27,9 @@ function obj = privateGetPortString(obj)
     % Print which ports we have found
     fprintf('Ports found:\n');
     for k = 1:length(indices)
-        fprintf('[%d]: %s\n', k, obj.portDeviceFiles(indices(k)).name);
+        fprintf('[%d]: %s\n', k, portDeviceFiles(indices(k)).name);
     end
 
-    obj.portString = sprintf('/dev/%s',obj.portDeviceFiles(indices(1)).name);
+    obj.portString = sprintf('/dev/%s',portDeviceFiles(indices(1)).name);
     fprintf('Will attempt to open %s.\n', obj.portString);
 end % getPortString


### PR DESCRIPTION
Device files are not a property of the radiometer object, and thus should not be enumerated as such on object/class initialization. If the state of the system changes, i.e., a device gets added, the object property does not get updated, and thus does not reflect the state of the system anymore.
Instead, enumerate device files when necessary, i.e., inside `privateGetPortString`. This ensures that we have the most up to date state of the system when actually attempting to open a port.